### PR TITLE
fix: same session skips reloading the css

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -52,6 +52,7 @@ class Extension {
         this.kbdSettings = Settings.getSettings("org.gnome.shell.extensions.forge.keybindings");
         this.configMgr = new Settings.ConfigManager();
         this.theme = new Theme.ThemeManager(this.settings, this.configMgr);
+        this.theme.reloadStylesheet();
 
         if (this.sameSession) {
             Logger.debug(`enable: still in same session`);
@@ -74,7 +75,6 @@ class Extension {
 
         this.extWm.enable();
         this.keybindings.enable();
-        this.theme.reloadStylesheet();
         Logger.info(`enable: finalized vars`);
     }
 


### PR DESCRIPTION
The same session flag when user locks screen skips the reloading of the custom stylesheet. Gnome-shell always reloads the default stylesheet.css from any active extension's install dir.

Fixes #86 