### PR TITLE
feat: option to choose default dnd layout (introduces appearance layout page)

### DIFF
--- a/messages.js
+++ b/messages.js
@@ -55,6 +55,10 @@ var prefs_appearance_color_border_editor_mode = _("Editor Mode");
 var prefs_appearance_color_border_changes_apply = _("Apply Changes");
 var prefs_appearance_color_border_size_reset = _("Reset");
 var prefs_appearance_color_border_color_reset = _("Reset");
+var prefs_appearance_layout = _("Layout");
+var prefs_appearance_layout_dnd_default_layout = _("Default Drag-and-Drop Center Layout");
+var prefs_appearance_layout_dnd_default_layout_option_tabbed = _("Tabbed");
+var prefs_appearance_layout_dnd_default_layout_option_stacked = _("Stacked");
 
 var prefs_workspace_settings = _("Workspace");
 var prefs_workspace_settings_title = _("Update Workspace Settings");

--- a/prefs.js
+++ b/prefs.js
@@ -173,6 +173,7 @@ var PrefsWidget = GObject.registerClass(
             // Appearance
             let appearanceSettingsBox = new ScrollStackBox(this, { widthRequest: leftBoxWidth });
             appearanceSettingsBox.addStackRow("Window", Msgs.prefs_appearance_windows, `${Me.path}/icons/prefs/focus-windows-symbolic.svg`);
+            appearanceSettingsBox.addStackRow("Layout", Msgs.prefs_appearance_layout, `${Me.path}/icons/prefs/preferences-desktop-wallpaper-symbolic.svg`);
             appearanceSettingsBox.addStackRow("Color", Msgs.prefs_appearance_color, `${Me.path}/icons/prefs/color-select-symbolic.svg`);
             this.settingsStack.add_named(appearanceSettingsBox, "AppearanceSettings");
 
@@ -191,6 +192,7 @@ var PrefsWidget = GObject.registerClass(
             this.settingsPagesStack.add_named(new UnderConstructionPanel(this, "Home"), "Home");
             this.settingsPagesStack.add_named(new UnderConstructionPanel(this, "Appearance"), "Appearance");
             this.settingsPagesStack.add_named(new AppearanceWindowSettingsPanel(this), "Window");
+            this.settingsPagesStack.add_named(new AppearanceLayoutSettingsPanel(this), "Layout");
             this.settingsPagesStack.add_named(new AppearanceColorSettingsPanel(this), "Color");
             this.settingsPagesStack.add_named(new WorkspaceSettingsPanel(this), "Workspace");
             this.settingsPagesStack.add_named(new UnderConstructionPanel(this, "Keyboard"), "Keyboard");
@@ -490,6 +492,42 @@ var AppearanceWindowSettingsPanel = GObject.registerClass(
             appearanceWindowFrame.add(gapHiddenWhenSingleRow);
 
             this.append(appearanceWindowFrame);
+        }
+    }
+);
+
+var AppearanceLayoutSettingsPanel = GObject.registerClass(
+    class AppearanceLayoutSettingsPanel extends PanelBox {
+        _init(prefsWidget) {
+            super._init(prefsWidget, `Appearance Layout Settings`);
+            this.settings = prefsWidget.settings;
+
+            let appearanceLayoutFrame = new FrameListBox();
+
+            // default drag-and-drop layout when grouping
+            let defaultDndLayout = new ListBoxRow();
+            let defaultLayoudDndLabel = new Gtk.Label({
+                label: `${Msgs.prefs_appearance_layout_dnd_default_layout}`,
+                use_markup: true,
+                xalign: 0,
+                hexpand: true
+            });
+            let defaultDndLayoutCombo = new Gtk.ComboBoxText();
+            // uppercase IDs break drag-and-drop center area color
+            defaultDndLayoutCombo.append("tabbed", `${Msgs.prefs_appearance_layout_dnd_default_layout_option_tabbed}`);
+            defaultDndLayoutCombo.append("stacked", `${Msgs.prefs_appearance_layout_dnd_default_layout_option_stacked}`);
+            let currentDndLayout = this.settings.get_string("dnd-center-layout");
+            defaultDndLayoutCombo.set_active_id(`${currentDndLayout}`);
+            defaultDndLayoutCombo.connect("changed", () => {
+                let activeId = defaultDndLayoutCombo.get_active_id();
+                this.settings.set_string("dnd-center-layout", activeId);
+            });
+            defaultDndLayout.add(defaultLayoudDndLabel);
+            defaultDndLayout.add(defaultDndLayoutCombo);
+
+            appearanceLayoutFrame.add(defaultDndLayout);
+
+            this.append(appearanceLayoutFrame);
         }
     }
 );

--- a/schemas/org.gnome.shell.extensions.forge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.forge.gschema.xml
@@ -104,7 +104,7 @@
             <default>'tabbed'</default>
             <summary>
                 The default center layout when dragging/dropping a window.
-                The other value is `tabbed`.
+                The values are `tabbed` and `stacked`.
             </summary>
         </key>
     </schema>


### PR DESCRIPTION
Hello,

I found that there is already a settings key for the default drag-and-drop center layout and the code already considers having this as a variable so I only had to add the settings page views. This commit leaves the Home page as it is and adds a new General settings page, as I was not sure in which other category such option fits (something like "Behavior" would work too).

This is my first time working on something like this so I would appreciate any feedback! I mostly copied code from other similar parts of the extension.

#101 