### PR TITLE
Add window rect check

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -1227,8 +1227,12 @@ var Tree = GObject.registerClass(
         .filter((t) => t.nodeType === NODE_TYPES.WINDOW);
       tiledChildren.forEach((w) => {
         if (w.renderRect) {
-          let metaWin = w.nodeValue;
-          this.extWm.move(metaWin, w.renderRect);
+          if (w.renderRect.width > 0 && w.renderRect.height > 0) {
+            let metaWin = w.nodeValue;
+            this.extWm.move(metaWin, w.renderRect);
+          } else {
+            Logger.debug(`ignoring apply for ${w.renderRect.width}x${w.renderRect.height}`);
+          }
         }
 
         if (w.nodeValue.firstRender) w.nodeValue.firstRender = false;

--- a/tree.js
+++ b/tree.js
@@ -1351,13 +1351,15 @@ var Tree = GObject.registerClass(
       let nodeY = node.rect.y;
       let gap = this.extWm.calculateGaps();
 
-      nodeX += gap;
-      nodeY += gap;
+      if ((nodeWidth > (gap * 2)) && (nodeHeight > (gap * 2))) {
+        nodeX += gap;
+        nodeY += gap;
 
-      // TODO - detect inbetween windows and adjust accordingly
-      // Also adjust depending on display scaling
-      nodeWidth -= gap * 2;
-      nodeHeight -= gap * 2;
+        // TODO - detect inbetween windows and adjust accordingly
+        // Also adjust depending on display scaling
+        nodeWidth -= gap * 2;
+        nodeHeight -= gap * 2;
+      }
       return { x: nodeX, y: nodeY, width: nodeWidth, height: nodeHeight };
     }
 
@@ -1555,6 +1557,10 @@ var Tree = GObject.registerClass(
         if (node.isCon() || node.isMonitor()) {
           attributes += `,layout:${node.layout}`;
         }
+      }
+
+      if (node.rect) {
+        attributes += `,rect:${node.rect.width}x${node.rect.height}+${node.rect.x}+${node.rect.y}`;
       }
 
       if (level !== 0) Logger.debug(`${spacing}|`);


### PR DESCRIPTION
With Ubuntu 22.10's gnome-shell (43.1) and the current version on extensions.gnome.org (version 61?)...

I've been seeing some oddities when unlocking after leaving it locked for a "little while".  I _think_ it's because X is bouncing the DisplayPort display...?

```
gnome-shell[2846]: meta_monitor_manager_get_logical_monitor_from_number: assertion '(unsigned int) number < g_list_length (manager->logical_monitors)' failed
gnome-shell[2846]: meta_workspace_get_work_area_for_monitor: assertion 'logical_monitor != NULL' failed
...
gnome-shell[2846]: *** BUG ***
gnome-shell[2846]: In pixman_region32_init_rect: Invalid rectangle passed
gnome-shell[2846]: Set a breakpoint on '_pixman_log_error' to debug
```

After some judicious littering of Logger calls, I noticed that the padding computation was resulting in negative width and height values.  I have no clue why it would happen, but adding a sanity check made the "invalid rectangle passed" error go away, and things seem to be working properly.



With the change and DEBUG logging enabled, it showed all the MONITOR and WINDOW nodes with zero-sized rects.

For example,
```
Forge: [DEBUG] render tree from workareas-changed
...
Forge: [DEBUG]     |   *--> MONITOR#0 @mo0ws0,layout:HSPLIT,rect:0x0+0+0
...
```


Note: I'm still not sure why the "monitor" assertions trigger yet, but it doesn't seem to be causing any problems.