### PR TITLE
Ignore workareas-changed event with no monitor

### DIFF
--- a/window.js
+++ b/window.js
@@ -175,6 +175,10 @@ var WindowManager = GObject.registerClass(
           this.renderTree("full-screen-changed");
         }),
         display.connect("workareas-changed", (_display) => {
+          if (global.display.get_n_monitors() == 0) {
+            Logger.debug(`workareas-changed: no monitors, ignoring signal`);
+            return;
+          }
           if (this.tree.getNodeByType("WINDOW").length > 0) {
             let workspaceReload = this.workspaceAdded || this.workspaceRemoved;
             if (workspaceReload) {


### PR DESCRIPTION
Fixes #182.

After a few days of testing, the change seems stable.  Or at least, nothing outwardly visible has gone worse.
Leaving the change at the "most minimal" to keep the change halo as tight as possible, just in case.

Note that this fix also fixes these specific gnome-shell assertions that were happening:
```
gnome-shell[3147]: meta_monitor_manager_get_logical_monitor_from_number: assertion '(unsigned int) number < g_list_length (manager->logical_monitors)' failed
gnome-shell[3147]: meta_workspace_get_work_area_for_monitor: assertion 'logical_monitor != NULL' failed
```