### PR TITLE
Resize enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ Forge is a GNOME Shell extension that provides tiling/window management.
 - Download/clone the source and `make install`, restart gnome-shell after or `make dev`.
 - AUR Package: https://aur.archlinux.org/packages/gnome-shell-extension-forge - thanks to [@Radeox](https://github.com/Radeox)
 
-## ! Major Changes !
-- Implemented quarter tiling. See https://github.com/jmmaranan/forge/issues/166. Toggle available on preferences
-- Implemented floating windows are default always on top. Toggle available on preferences
-
 ## Development
 - The `main` branch contains gnome-4x code.
 - The `legacy` and `gnome-3-36` are the same and is now the source for gnome-3x.
@@ -35,6 +31,7 @@ Forge is a GNOME Shell extension that provides tiling/window management.
 - Swap current window with the last active window
 - Auto Split or Quarter Tiling
 - Show/hide tab decoration via keybinding https://github.com/jmmaranan/forge/issues/180
+- Window resize using keyboard shortcuts
 
 ![image](https://user-images.githubusercontent.com/348125/146386593-8f53ea8b-2cf3-4d44-a613-bbcaf89f9d4a.png)
 
@@ -43,7 +40,14 @@ Forge is a GNOME Shell extension that provides tiling/window management.
 ### New
 | Action | Shortcut |
 | --- | --- |
-| Show/hide tab decoration | `<Ctrl> + <Alt> + y` |
+| Increase active window size left | `<Ctrl> + <Super> + y` |
+| Decrease active window size left | `<Ctrl> + <Shift> + <Super> + o` |
+| Increase active window size bottom | `<Ctrl> + <Super> + u` |
+| Decrease active window size bottom | `<Ctrl> + <Shift> + <Super> + i` |
+| Increase active window size top | `<Ctrl> + <Super> + i` |
+| Decrease active window size top | `<Ctrl> + <Shift> + <Super> + u` |
+| Increase active window size right | `<Ctrl> + <Super> + o` |
+| Decrease active window size right | `<Ctrl> + <Shift> + <Super> + y` |
 
 ### Current
 
@@ -73,6 +77,7 @@ Forge is a GNOME Shell extension that provides tiling/window management.
 | Toggle active workspace tiling | `<Shift> + <Super> + w` |
 | Toggle stacked layout | `<Shift> + <Super> + s` |
 | Toggle tabbed layout | `<Shift> + <Super> + t` |
+| Show/hide tab decoration | `<Ctrl> + <Alt> + y` |
 | Activate tile drag-drop | `Start dragging - Mod key configuration in prefs` |
 | Snap active window left two thirds | `<Ctrl> + <Alt> + e` |
 | Snap active window right two thirds | `<Ctrl> + <Alt> + t` |

--- a/config/windows.json
+++ b/config/windows.json
@@ -15,6 +15,7 @@
     { "wmClass": "gnome-calculator", "mode": "float" },
     { "wmClass": "Gnome-terminal", "wmTitle": "Preferences – General", "mode": "float" },
     { "wmClass": "Guake", "mode": "float" },
-    { "wmClass": "zoom", "mode": "float" }
+    { "wmClass": "zoom", "mode": "float" },
+    { "wmClass": "Spotify", "mode": "float" }
   ]
 }

--- a/keybindings.js
+++ b/keybindings.js
@@ -438,6 +438,30 @@ var Keybindings = GObject.registerClass(
           };
           this.extWm.command(action);
         },
+        "window-resize-vertical-increase": () => {
+          let action = {
+            name: "WindowResizeVerticalIncrease",
+          };
+          this.extWm.command(action);
+        },
+        "window-resize-vertical-decrease": () => {
+          let action = {
+            name: "WindowResizeVerticalDecrease",
+          };
+          this.extWm.command(action);
+        },
+        "window-resize-horizontal-increase": () => {
+          let action = {
+            name: "WindowResizeHorizontalIncrease",
+          };
+          this.extWm.command(action);
+        },
+        "window-resize-horizontal-decrease": () => {
+          let action = {
+            name: "WindowResizeHorizontalDecrease",
+          };
+          this.extWm.command(action);
+        },
       };
     }
   }

--- a/keybindings.js
+++ b/keybindings.js
@@ -438,27 +438,59 @@ var Keybindings = GObject.registerClass(
           };
           this.extWm.command(action);
         },
-        "window-resize-vertical-increase": () => {
+        "window-resize-top-increase": () => {
           let action = {
-            name: "WindowResizeVerticalIncrease",
+            name: "WindowResizeTop",
+            amount: this.settings.get_uint("resize-amount"),
           };
           this.extWm.command(action);
         },
-        "window-resize-vertical-decrease": () => {
+        "window-resize-top-decrease": () => {
           let action = {
-            name: "WindowResizeVerticalDecrease",
+            name: "WindowResizeTop",
+            amount: -1 * this.settings.get_uint("resize-amount"),
           };
           this.extWm.command(action);
         },
-        "window-resize-horizontal-increase": () => {
+        "window-resize-bottom-increase": () => {
           let action = {
-            name: "WindowResizeHorizontalIncrease",
+            name: "WindowResizeBottom",
+            amount: this.settings.get_uint("resize-amount"),
           };
           this.extWm.command(action);
         },
-        "window-resize-horizontal-decrease": () => {
+        "window-resize-bottom-decrease": () => {
           let action = {
-            name: "WindowResizeHorizontalDecrease",
+            name: "WindowResizeBottom",
+            amount: -1 * this.settings.get_uint("resize-amount"),
+          };
+          this.extWm.command(action);
+        },
+        "window-resize-left-increase": () => {
+          let action = {
+            name: "WindowResizeLeft",
+            amount: this.settings.get_uint("resize-amount"),
+          };
+          this.extWm.command(action);
+        },
+        "window-resize-left-decrease": () => {
+          let action = {
+            name: "WindowResizeLeft",
+            amount: -1 * this.settings.get_uint("resize-amount"),
+          };
+          this.extWm.command(action);
+        },
+        "window-resize-right-increase": () => {
+          let action = {
+            name: "WindowResizeRight",
+            amount: this.settings.get_uint("resize-amount"),
+          };
+          this.extWm.command(action);
+        },
+        "window-resize-right-decrease": () => {
+          let action = {
+            name: "WindowResizeRight",
+            amount: -1 * this.settings.get_uint("resize-amount"),
           };
           this.extWm.command(action);
         },

--- a/schemas/org.gnome.shell.extensions.forge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.forge.gschema.xml
@@ -292,5 +292,21 @@
         <key type="as" name="window-snap-center">
           <default><![CDATA[['<Ctrl><Alt>c']]]></default>
         </key>
+
+        <key type="as" name="window-resize-horizontal-increase">
+          <default><![CDATA[['<Ctrl><Super>o']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-horizontal-decrease">
+          <default><![CDATA[['<Ctrl><Super>y']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-vertical-increase">
+          <default><![CDATA[['<Ctrl><Super>i']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-vertical-decrease">
+          <default><![CDATA[['<Ctrl><Super>u']]]></default>
+        </key>
     </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.forge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.forge.gschema.xml
@@ -34,6 +34,13 @@
             </summary>
         </key>
 
+        <key type="u" name="resize-amount">
+            <default>15</default>
+            <summary>
+                The size of the gap between windows in the workarea
+            </summary>
+        </key>
+
         <key type="u" name="window-gap-size-increment">
             <default>1</default>
             <summary>
@@ -127,6 +134,7 @@
             <default>true</default>
             <summary>Whether to show the tab decoration or not</summary>
         </key>
+
     </schema>
     <schema id="org.gnome.shell.extensions.forge.keybindings" path="/org/gnome/shell/extensions/forge/keybindings/">
         <!-- Keybinding Settings -->
@@ -293,20 +301,36 @@
           <default><![CDATA[['<Ctrl><Alt>c']]]></default>
         </key>
 
-        <key type="as" name="window-resize-horizontal-increase">
-          <default><![CDATA[['<Ctrl><Super>o']]]></default>
-        </key>
-
-        <key type="as" name="window-resize-horizontal-decrease">
+        <key type="as" name="window-resize-left-increase">
           <default><![CDATA[['<Ctrl><Super>y']]]></default>
         </key>
 
-        <key type="as" name="window-resize-vertical-increase">
+        <key type="as" name="window-resize-left-decrease">
+            <default><![CDATA[['<Ctrl><Shift><Super>o']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-bottom-increase">
+          <default><![CDATA[['<Ctrl><Super>u']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-bottom-decrease">
+            <default><![CDATA[['<Ctrl><Shift><Super>i']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-top-increase">
           <default><![CDATA[['<Ctrl><Super>i']]]></default>
         </key>
 
-        <key type="as" name="window-resize-vertical-decrease">
-          <default><![CDATA[['<Ctrl><Super>u']]]></default>
+        <key type="as" name="window-resize-top-decrease">
+            <default><![CDATA[['<Ctrl><Shift><Super>u']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-right-increase">
+          <default><![CDATA[['<Ctrl><Super>o']]]></default>
+        </key>
+
+        <key type="as" name="window-resize-right-decrease">
+            <default><![CDATA[['<Ctrl><Shift><Super>y']]]></default>
         </key>
     </schema>
 </schemalist>

--- a/window.js
+++ b/window.js
@@ -724,6 +724,7 @@ var WindowManager = GObject.registerClass(
                 this.renderTree("snap-layout-move");
               },
             });
+            break;
           }
 
         case "ShowTabDecorationToggle":
@@ -738,9 +739,62 @@ var WindowManager = GObject.registerClass(
           this.renderTree("showtab-decoration-enabled");
           break;
 
+        case "WindowResizeHorizontalIncrease":
+          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_E);
+          break;
+        case "WindowResizeHorizontalDecrease":
+          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_W);
+          break;
+        case "WindowResizeVerticalIncrease":
+          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_N);
+          break;
+        case "WindowResizeVerticalDecrease":
+          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_S);
+          break;
+
         default:
           break;
       }
+    }
+
+    resize(amount, grabOp) {
+      this.queueEvent({
+        name: "queue-resize",
+        callback: () => {
+          let metaWindow = this.focusMetaWindow;
+          let display = global.display;
+
+          this._handleGrabOpBegin(display, metaWindow, grabOp);
+
+          let rect = metaWindow.get_frame_rect();
+          let direction = Utils.directionFromGrab(grabOp);
+
+          switch (direction) {
+            case Meta.MotionDirection.RIGHT:
+              rect.width = rect.width + amount;
+              break;
+            case Meta.MotionDirection.LEFT:
+              rect.width = rect.width - amount;
+              rect.x = rect.x + amount;
+              break;
+            case Meta.MotionDirection.UP:
+              rect.height = rect.height + amount;
+              break;
+            case Meta.MotionDirection.DOWN:
+              rect.height = rect.height - amount;
+              rect.y = rect.y + amount;
+              break;
+          }
+
+          this.move(metaWindow, rect);
+          this.queueEvent({
+            name: "manual-resize",
+            callback: () => {
+              this._handleGrabOpEnd(display, metaWindow, grabOp);
+            },
+          });
+        },
+      });
     }
 
     disable() {

--- a/window.js
+++ b/window.js
@@ -739,20 +739,20 @@ var WindowManager = GObject.registerClass(
           this.renderTree("showtab-decoration-enabled");
           break;
 
-        case "WindowResizeHorizontalIncrease":
-          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_E);
+        case "WindowResizeRight":
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_E, action.amount);
           break;
 
-        case "WindowResizeHorizontalDecrease":
-          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_W);
+        case "WindowResizeLeft":
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_W, action.amount);
           break;
 
-        case "WindowResizeVerticalIncrease":
-          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_N);
+        case "WindowResizeTop":
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_N, action.amount);
           break;
 
-        case "WindowResizeVerticalDecrease":
-          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_S);
+        case "WindowResizeBottom":
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_S, action.amount);
           break;
 
         default:
@@ -760,10 +760,9 @@ var WindowManager = GObject.registerClass(
       }
     }
 
-    resize(grabOp) {
+    resize(grabOp, amount) {
       let metaWindow = this.focusMetaWindow;
       let display = global.display;
-      let amount = 15;
 
       this._handleGrabOpBegin(display, metaWindow, grabOp);
 

--- a/window.js
+++ b/window.js
@@ -740,16 +740,19 @@ var WindowManager = GObject.registerClass(
           break;
 
         case "WindowResizeHorizontalIncrease":
-          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_E);
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_E);
           break;
+
         case "WindowResizeHorizontalDecrease":
-          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_W);
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_W);
           break;
+
         case "WindowResizeVerticalIncrease":
-          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_N);
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_N);
           break;
+
         case "WindowResizeVerticalDecrease":
-          this.resize(5, Meta.GrabOp.KEYBOARD_RESIZING_S);
+          this.resize(Meta.GrabOp.KEYBOARD_RESIZING_S);
           break;
 
         default:
@@ -757,44 +760,44 @@ var WindowManager = GObject.registerClass(
       }
     }
 
-    resize(amount, grabOp) {
-      this.queueEvent({
-        name: "queue-resize",
-        callback: () => {
-          let metaWindow = this.focusMetaWindow;
-          let display = global.display;
+    resize(grabOp) {
+      let metaWindow = this.focusMetaWindow;
+      let display = global.display;
+      let amount = 15;
 
-          this._handleGrabOpBegin(display, metaWindow, grabOp);
+      this._handleGrabOpBegin(display, metaWindow, grabOp);
 
-          let rect = metaWindow.get_frame_rect();
-          let direction = Utils.directionFromGrab(grabOp);
+      let rect = metaWindow.get_frame_rect();
+      let direction = Utils.directionFromGrab(grabOp);
 
-          switch (direction) {
-            case Meta.MotionDirection.RIGHT:
-              rect.width = rect.width + amount;
-              break;
-            case Meta.MotionDirection.LEFT:
-              rect.width = rect.width - amount;
-              rect.x = rect.x + amount;
-              break;
-            case Meta.MotionDirection.UP:
-              rect.height = rect.height + amount;
-              break;
-            case Meta.MotionDirection.DOWN:
-              rect.height = rect.height - amount;
-              rect.y = rect.y + amount;
-              break;
-          }
-
-          this.move(metaWindow, rect);
-          this.queueEvent({
-            name: "manual-resize",
-            callback: () => {
+      switch (direction) {
+        case Meta.MotionDirection.RIGHT:
+          rect.width = rect.width + amount;
+          break;
+        case Meta.MotionDirection.LEFT:
+          rect.width = rect.width + amount;
+          rect.x = rect.x - amount;
+          break;
+        case Meta.MotionDirection.UP:
+          rect.height = rect.height + amount;
+          break;
+        case Meta.MotionDirection.DOWN:
+          rect.height = rect.height + amount;
+          rect.y = rect.y - amount;
+          break;
+      }
+      this.move(metaWindow, rect);
+      this.queueEvent(
+        {
+          name: "manual-resize",
+          callback: () => {
+            if (this.eventQueue.length === 0) {
               this._handleGrabOpEnd(display, metaWindow, grabOp);
-            },
-          });
+            }
+          },
         },
-      });
+        50
+      );
     }
 
     disable() {


### PR DESCRIPTION
Fixes #111 

- Initial rough implementation. It works on Tiled and Floating windows
- Redraw issue when long pressing keybindings - moves the window the wrong way, so user has to press in intervals. Will need to figure out queuing events properly.
- This is a separate implementation from the GNOME built in resize, usually bound at Alt + F8