### PR TITLE
Don't resize other windows when resizing floats

### DIFF
--- a/window.js
+++ b/window.js
@@ -2206,7 +2206,7 @@ var WindowManager = GObject.registerClass(
     }
 
     _handleResizing(focusNodeWindow) {
-      if (!focusNodeWindow) return;
+      if (!focusNodeWindow || focusNodeWindow.isFloat()) return;
       let grabOp = this.grabOp;
       let initGrabOp = focusNodeWindow.initGrabOp;
       let direction = Utils.directionFromGrab(grabOp);


### PR DESCRIPTION
### Repro case

probably not the smallest repro, but it's what I got...


> 1. create 3 windows, so you have 3 columns.
> It ends up looking like:
> ```
> *--> WORKSPACE#1 @ws1
> |   *--> MONITOR#0
> |   |   *--> CON#0
> |   |   |   *--> WINDOW#0
> |   |   *--> CON#1
> |   |   |   *--> WINDOW#0
> |   |   *--> WINDOW#2
> ```
> 
> 2. apply focus on "the leftmost window"
> 
> 3. open up a window that is "already focused" (e.g. Zoom)
> ```
> *--> WORKSPACE#1 @ws1
> |   *--> MONITOR#0
> |   |   *--> CON#0
> |   |   |   *--> WINDOW#0 ... rect:...
> |   |   |   *--> WINDOW#1
> |   |   *--> CON#1
> |   |   |   *--> WINDOW#0
> |   |   *--> WINDOW#2
> ```
> 
> 4. adjust the width of the zoom window.

In my tests, CON#0  would adjust in width. Sometimes it'd push the rightmost window off the right side of the screen.



This patch neuters all the forge resize logic for floating windows?  I think?