### PR TITLE
Fix focus-down regression when pointer warp disabled

### DIFF
--- a/lib/extension/tree.js
+++ b/lib/extension/tree.js
@@ -831,6 +831,7 @@ export class Tree extends Node {
 
     let metaWindow = next.nodeValue;
     if (!metaWindow) return null;
+    const previousMetaWindow = this.extWm.focusMetaWindow;
     if (metaWindow.minimized) {
       next = this.focus(next, direction);
     } else {
@@ -838,14 +839,18 @@ export class Tree extends Node {
       metaWindow.focus(global.display.get_current_time());
       metaWindow.activate(global.display.get_current_time());
 
+      const monitorArea = metaWindow.get_work_area_current_monitor();
+      const ptr = this.extWm.getPointer();
+      const pointerInside = Utils.rectContainsPoint(monitorArea, [ptr[0], ptr[1]]);
+      const monitorChanged =
+        !!previousMetaWindow &&
+        previousMetaWindow.get_monitor &&
+        previousMetaWindow.get_monitor() !== metaWindow.get_monitor();
+
       if (this.settings.get_boolean("move-pointer-focus-enabled")) {
         this.extWm.movePointerWith(next);
-      } else {
-        let monitorArea = metaWindow.get_work_area_current_monitor();
-        let ptr = this.extWm.getPointer();
-        if (!Utils.rectContainsPoint(monitorArea, [ptr[0], ptr[1]])) {
-          this.extWm.movePointerWith(next);
-        }
+      } else if (!pointerInside) {
+        this.extWm.movePointerWith(next, { force: monitorChanged });
       }
     }
     return next;

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -1864,9 +1864,10 @@ export class WindowManager extends GObject.Object {
    * This is useful for making sure that Forge calculates the attachNode
    * properly
    */
-  movePointerWith(nodeWindow) {
+  movePointerWith(nodeWindow, { force = false } = {}) {
     if (!nodeWindow || !nodeWindow._data) return;
-    if (this.ext.settings.get_boolean("move-pointer-focus-enabled")) {
+    const shouldWarp = force || this.ext.settings.get_boolean("move-pointer-focus-enabled");
+    if (shouldWarp) {
       this.storePointerLastPosition(this.lastFocusedWindow);
       if (this.canMovePointerInsideNodeWindow(nodeWindow)) {
         this.warpPointerToNodeWindow(nodeWindow);


### PR DESCRIPTION
## Summary
- fix the regression where the “focus down” action can no longer reach a tiled window on the secondary monitor when the pointer is parked on the primary monitor
- keep focus hotkeys working across monitors even when “Move pointer with focus” is disabled
- only warp the cursor when either the setting is enabled or focus crosses to a different monitor, so same-monitor focus changes keep the pointer steady

## Impact
- users running multi-monitor setups on Wayland with pointer warp disabled regain reliable cross-monitor focus navigation without reintroducing pointer jumps

## Testing
- GNOME 46.3 (Wayland)
- Move pointer with focus disabled
- Focus down action now reaches a tiled window on the secondary display while the pointer remains stationary
