### PR TITLE
Keep focus on pointer monitor after workspace switch

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -74,6 +74,8 @@ export class WindowManager extends GObject.Object {
     this.eventQueue = new Queue();
     this.theme = this.ext.theme;
     this.lastFocusedWindow = null;
+    this.lastFocusedWindowMonitor = undefined;
+    this.lastFocusedWindowWorkspace = undefined;
     this.shouldFocusOnHover = this.ext.settings.get_boolean("focus-on-hover-enabled");
 
     Logger.info("forge initialized");
@@ -267,10 +269,27 @@ export class WindowManager extends GObject.Object {
         this.renderTree("workspace-removed");
       }),
       globalWsm.connect("active-workspace-changed", () => {
+        const pointerMonitor = global.display.get_current_monitor();
+        const pointerWorkspace = global.display
+          .get_workspace_manager()
+          .get_active_workspace_index();
+
         this.hideWindowBorders();
         this.trackCurrentMonWs();
         this.updateDecorationLayout();
         this.renderTree("active-workspace-changed");
+
+        if (this.ext.settings.get_boolean("move-pointer-focus-enabled")) {
+          this.queueEvent(
+            {
+              name: "refocus-pointer-monitor",
+              callback: () => {
+                this.refocusPointerMonitor(pointerMonitor, pointerWorkspace);
+              },
+            },
+            16
+          );
+        }
       }),
     ];
 
@@ -400,9 +419,25 @@ export class WindowManager extends GObject.Object {
   trackCurrentMonWs() {
     let metaWindow = this.focusMetaWindow;
     if (!metaWindow) return;
-    const currentMonitor = global.display.get_current_monitor();
     const currentWorkspace = global.display.get_workspace_manager().get_active_workspace_index();
 
+    if (this.lastFocusedWindowMonitor !== undefined) {
+      const pointerMonitor = this.lastFocusedWindowMonitor;
+      let pointerMonWs = `mo${pointerMonitor}ws${currentWorkspace}`;
+      let pointerMonWsNode = this.tree.findNode(pointerMonWs);
+      if (pointerMonWsNode) {
+        const pointerWindows = pointerMonWsNode
+          .getNodeByType(NODE_TYPES.WINDOW)
+          .filter((w) => w.isTile())
+          .map((w) => w.nodeValue);
+        if (pointerWindows.length > 0) {
+          this.sortedWindows = global.display.sort_windows_by_stacking(pointerWindows).reverse();
+          return;
+        }
+      }
+    }
+
+    const currentMonitor = global.display.get_current_monitor();
     let currentMonWs = `mo${currentMonitor}ws${currentWorkspace}`;
     let activeMetaMonWs = `mo${metaWindow.get_monitor()}ws${metaWindow.get_workspace().index()}`;
     let currentWsNode = this.tree.findNode(`ws${currentWorkspace}`);
@@ -1872,8 +1907,52 @@ export class WindowManager extends GObject.Object {
         this.warpPointerToNodeWindow(nodeWindow);
       }
     }
+
+    if (nodeWindow && nodeWindow.nodeValue) {
+      this.lastFocusedWindowMonitor = nodeWindow.nodeValue.get_monitor();
+      let workspace = nodeWindow.nodeValue.get_workspace();
+      this.lastFocusedWindowWorkspace = workspace ? workspace.index() : undefined;
+    } else {
+      this.lastFocusedWindowMonitor = undefined;
+      this.lastFocusedWindowWorkspace = undefined;
+    }
     this.lastFocusedWindow = nodeWindow;
     this.tree.debugParentNodes(nodeWindow);
+  }
+
+  refocusPointerMonitor(monitor, workspace) {
+    if (monitor === undefined || workspace === undefined) return;
+
+    const focusWindow = global.display.get_focus_window();
+    if (focusWindow && focusWindow.get_monitor && focusWindow.get_monitor() === monitor) {
+      return;
+    }
+
+    const candidateNodes = this.tree
+      .getNodeByType(NODE_TYPES.WINDOW)
+      .filter((node) => {
+        if (!node.isTile()) return false;
+        const meta = node.nodeValue;
+        if (!meta || meta.minimized) return false;
+        const metaWorkspace = meta.get_workspace();
+        return meta.get_monitor() === monitor && metaWorkspace && metaWorkspace.index() === workspace;
+      });
+
+    if (candidateNodes.length === 0) return;
+
+    const sortedMetas = global.display
+      .sort_windows_by_stacking(candidateNodes.map((node) => node.nodeValue))
+      .reverse();
+    const targetMeta = sortedMetas.find(Boolean);
+    if (!targetMeta) return;
+
+    const targetNode = candidateNodes.find((node) => node.nodeValue === targetMeta);
+    if (!targetNode) return;
+
+    targetMeta.raise();
+    targetMeta.focus(global.display.get_current_time());
+    targetMeta.activate(global.display.get_current_time());
+    this.movePointerWith(targetNode, { force: true });
   }
 
   warpPointerToNodeWindow(nodeWindow) {


### PR DESCRIPTION
## Summary
- fix the bug where enabling “Move pointer with the focus” causes workspace switches to highlight the window on a monitor whose workspace didn’t change
- reuse the pointer’s monitor/workspace when rebuilding the tree so focus returns to the monitor that actually switched workspaces
- after the workspace switch completes, refocus and warp the pointer back to that monitor so it stays active

## Behavior Change
- Before: switching workspaces with pointer warp enabled caused Mutter to revive a static window on another monitor, Forge warped the pointer there, and focus jumped away from the monitor whose workspace you actually changed.
- After: Forge remembers which monitor the pointer belonged to, reorders its window list for that monitor, and re-applies focus (plus pointer warp) back to that monitor when the workspace switch finishes.

## Impact
- Multi-monitor users with pointer warping enabled keep focus on the monitor whose workspace they switched to, instead of having it jump to a static secondary display.

## Testing
- GNOME 46.3 (Wayland)
- `move-pointer-focus-enabled=true`
- Switching workspaces keeps focus/pointer on the monitor associated with the new workspace; other monitors no longer steal focus.
