### PR TITLE
fix toggle floating regression, closes #492

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -103,8 +103,13 @@ export class WindowManager extends GObject.Object {
     let wmId = metaWindow.get_id();
 
     for (let override of overrides) {
-      // if the window is already floating
-      if (override.wmClass === wmClass && override.mode === "float" && !override.wmTitle) return;
+      // ignore already floating and find correct window instance
+      if (override.wmClass === wmClass && override.mode === "float" && !override.wmTitle) {
+        if (withWmId && override.wmId !== wmId) {
+          continue;
+        }
+        return;
+      }
     }
     overrides.push({
       wmClass: wmClass,
@@ -115,6 +120,7 @@ export class WindowManager extends GObject.Object {
     // Save the updated overrides back to the ConfigManager
     currentProps.overrides = overrides;
     this.ext.configMgr.windowProps = currentProps;
+    this.windowProps = currentProps;
   }
 
   removeFloatOverride(metaWindow, withWmId) {
@@ -135,6 +141,7 @@ export class WindowManager extends GObject.Object {
     // Save the updated overrides back to the ConfigManager
     currentProps.overrides = overrides;
     this.ext.configMgr.windowProps = currentProps;
+    this.windowProps = currentProps;
   }
 
   toggleFloatingMode(action, metaWindow) {


### PR DESCRIPTION
### Disclosure

I am not familiar with gnome extension programming an used an LLM to generate these changes. Please review thoroughly.

### Test plan

I've been using this patch on multiple machines for the last week and have experienced no adverse behavior. The patch works as intended.

### Description

The bug was introduced in commit 8ad9c9b (PR 484) when refactoring to fix
dangling pointers. The refactoring changed addFloatOverride() and
removeFloatOverride() to work with fresh data from ConfigManager via
currentProps, but forgot to update the local this.windowProps cache.

This caused toggleFloatingMode() to fail because:
1. First toggle: addFloatOverride() saves to config but doesn't update cache
2. isFloatingExempt() still reads from old cache, doesn't see the new override
3. Second toggle: thinks window is still not floating, tries to add again
4. addFloatOverride() sees duplicate in fresh config data and returns early
5. No visual change occurs because the window state never actually toggles

The fix updates this.windowProps after modifying overrides in both
addFloatOverride() and removeFloatOverride() to keep the cache in sync.

Additionally, the early return check in addFloatOverride() was too aggressive
and would prevent adding wmId overrides for different windows of the same class.
The fix now properly checks wmId when withWmId is true, allowing multiple
windows of the same class to have individual wmId overrides.

Fixes: Super+C and Super+Shift+C shortcuts now properly toggle and persist
       floating window state as intended.

