### PR TITLE
Fix Portuguese (pt_BR) translation grammar and spelling errors

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -321,13 +321,13 @@ msgstr "Empilhado"
 
 #: lib/prefs/settings.js:116
 msgid "Always on Top mode for floating windows"
-msgstr "Modo sempre no topo par janelas flutuantes"
+msgstr "Modo sempre no topo para janelas flutuantes"
 
 #: lib/prefs/settings.js:117
 #, fuzzy
 msgid "Makes floating windows appear above tiled windows"
 msgstr ""
-"Modo Flutuante Sempre no Topo (Janelas flutuantes sempre acima de janelas "
+"Modo Flutuante Sempre no Topo (Janelas flutuantes sempre acima das janelas "
 "emparelhadas)"
 
 #: lib/prefs/settings.js:125
@@ -341,7 +341,7 @@ msgstr ""
 
 #: lib/prefs/settings.js:129
 msgid "Example: 0,1,2"
-msgstr "Examplo: 0,1,2"
+msgstr "Exemplo: 0,1,2"
 
 #: lib/prefs/settings.js:137
 #, fuzzy


### PR DESCRIPTION
This PR fixes several grammatical and spelling errors in the Portuguese Brazilian translation:

Fixed issues:
1. Line 116: Corrected "par janelas" → "para janelas" (preposition error)
2. Line 117: Fixed "acima de janelas" → "acima das janelas" (contraction error)
3. Line 129: Corrected "Examplo" → "Exemplo" (spelling error)

Changes made:
- Fixed preposition usage: "par" → "para"
- Corrected article contraction: "de + as" → "das"
- Fixed spelling: "Examplo" → "Exemplo"

These fixes improve the translation quality and ensure proper Portuguese grammar for Brazilian users.