### PR TITLE
Fix enabling "Auto exit tabbed tiling" also forces you to enable "Move pointer with focused window"

### DIFF
--- a/lib/prefs/settings.js
+++ b/lib/prefs/settings.js
@@ -98,7 +98,6 @@ export class SettingsPage extends PreferencesPage {
           subtitle: _("Exit tabbed tiling mode when only a single tab remains"),
           settings,
           bind: "auto-exit-tabbed",
-          bind: "move-pointer-focus-enabled",
         }),
         new DropDownRow({
           title: _("Drag-and-drop behavior"),


### PR DESCRIPTION
Looks like there's an extraneous "bind" added by mistake