### PR TITLE
fix: guard tree rendering against destroyed window actors

### DIFF
--- a/lib/extension/tree.js
+++ b/lib/extension/tree.js
@@ -459,7 +459,9 @@ export class Node extends GObject.Object {
       style_class: "window-tabbed-tab",
       x_expand: true,
     });
+    // Window tracker may not resolve an app for a dying window
     let app = this.app;
+    if (!app) return;
     let labelText = this._getTitle();
     let metaWin = this.nodeValue;
     let titleButton = new St.Button({
@@ -535,6 +537,21 @@ export class Node extends GObject.Object {
       return this.nodeValue.title ? this.nodeValue.title : this.app.get_name();
     }
     return null;
+  }
+
+  // Check if the underlying window actor is still alive. GJS throws
+  // on property access of finalized GObjects rather than segfaulting,
+  // so a cheap get_name() call is enough to detect dead actors.
+  isNodeValid() {
+    if (!this.isWindow()) return true;
+    try {
+      let actor = this._actor;
+      if (!actor) return false;
+      actor.get_name();
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 
   render() {
@@ -1274,8 +1291,12 @@ export class Tree extends Node {
     tiledChildren.forEach((w) => {
       if (w.renderRect) {
         if (w.renderRect.width > 0 && w.renderRect.height > 0) {
+          // Window may have been destroyed since processNode computed renderRect
           let metaWin = w.nodeValue;
-          this.extWm.move(metaWin, w.renderRect);
+          try {
+            this.extWm.move(metaWin, w.renderRect);
+          } catch (e) {
+          }
         } else {
           Logger.debug(`ignoring apply for ${w.renderRect.width}x${w.renderRect.height}`);
         }
@@ -1385,7 +1406,8 @@ export class Tree extends Node {
         });
       }
 
-      tiledChildren.forEach((child, index) => {
+      // Skip windows whose actors were destroyed mid-render
+      tiledChildren.filter((c) => c.isNodeValid()).forEach((child, index) => {
         // A monitor can contain a window or container child
         if (node.layout === LAYOUT_TYPES.HSPLIT || node.layout === LAYOUT_TYPES.VSPLIT) {
           this.processSplit(node, child, params, index);
@@ -1527,10 +1549,17 @@ export class Tree extends Node {
       if (node.childNodes.length > 1 || alwaysShowDecorationTab) {
         nodeY = nodeRect.y + params.stackedHeight;
         nodeHeight = nodeRect.height - params.stackedHeight;
-        if (node.decoration && child.isWindow()) {
+        if (node.decoration && child.isWindow() && child.isNodeValid()) {
           let gap = this.extWm.calculateGaps(node);
           let renderRect = this.processGap(node);
-          let borderWidth = child.actor.border.get_theme_node().get_border_width(St.Side.TOP);
+          // Border actor may be gone if the window was destroyed mid-render
+          let borderWidth = 0;
+          try {
+            if (child.actor?.border) {
+              borderWidth = child.actor.border.get_theme_node().get_border_width(St.Side.TOP);
+            }
+          } catch (e) {
+          }
 
           // Make adjustments to the gaps
           let adjust = 4 * Utils.dpi();
@@ -1552,7 +1581,12 @@ export class Tree extends Node {
             } else {
               decoration.hide();
             }
-            if (!decoration.contains(child.tab)) decoration.add_child(child.tab);
+            if (child.tab && !decoration.contains(child.tab)) {
+              try {
+                decoration.add_child(child.tab);
+              } catch (e) {
+              }
+            }
           }
 
           child.render();


### PR DESCRIPTION
Got kicked out of my entire GNOME session on Feb 20. No warning, just landed on an error page with a "log out" button.

1. `journalctl -b 0` told the story: signal 11 (SIGSEGV) in gnome-shell, then signal 6 (mutter assertion) right behind it. A double crash.
2. Signal 11 pointed at the Forge extension. Signal 6 was just mutter reacting to the mess.
3. Traced it into `tree.js` - the recursive `processNode()` traversal, line 1555.
4. Reproduced it: open a few windows in tabbed layout, `kill -9` one of them, watch gnome-shell die on the next render cycle.
5. The smoking gun was `child.actor.border.get_theme_node()` accessing a dead window's actor. The render pipeline just assumes everything is alive. GJS doesn't stop you from touching a finalized GObject - it lets the access through to C, and C doesn't ask twice.

Adds `isNodeValid()` that probes the actor with `get_name()` in a try/catch (GJS throws on finalized GObjects rather than segfaulting). Filters dead nodes out before layout, and guards the remaining property accesses that can race with window destruction.

**Tested** by opening 3 windows in tabbed layout, `kill -9`ing one, and confirming gnome-shell stayed up with no SIGSEGV or forge errors in `journalctl`.