### PR TITLE
fix: metadata build target — gawk dependency, missing redirect, missing HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ patchcss:
 
 metadata:
 	echo "export const developers = Object.entries([" > lib/prefs/metadata.js
-	git shortlog -sne || echo "" >> lib/prefs/metadata.js
-	awk -i inplace '!/dependabot|noreply/' lib/prefs/metadata.js
+	git shortlog -sne HEAD >> lib/prefs/metadata.js || echo "" >> lib/prefs/metadata.js
+	sed -i -E '/dependabot|noreply/d' lib/prefs/metadata.js
 	sed -i 's/^[[:space:]]*[0-9]*[[:space:]]*\(.*\) <\(.*\)>/  {name:"\1", email:"\2"},/g' lib/prefs/metadata.js
 	echo "].reduce((acc, x) => ({ ...acc, [x.email]: acc[x.email] ?? x.name }), {})).map(([email, name]) => name + ' <' + email + '>')" >> lib/prefs/metadata.js
 


### PR DESCRIPTION
## Summary

Building from source on Ubuntu/Debian produces a broken preferences dialog because the `metadata` Makefile target uses `awk -i inplace`, which is a gawk-only feature — these distros ship mawk as the default `awk`. Make aborts on the error, leaving `lib/prefs/metadata.js` truncated:

<img width="917" height="538" alt="Screenshot from 2026-02-26 11-39-16" src="https://github.com/user-attachments/assets/fbf42a81-f61b-4a70-9fdf-a5fea9559fd2" />


Also fixes two other bugs in the same target that made the developers list empty on **all** distros:

- `git shortlog -sne` output was going to stdout instead of the file (missing `>>`)
- `git shortlog` without explicit `HEAD` reads from stdin in non-interactive builds (CI, makepkg, rpmbuild), producing no output

## Changes

- Replace gawk-only `awk -i inplace` with portable `sed -i -E`
- Redirect shortlog output to the file with explicit `HEAD`