### PR TITLE
Update Windows-toggle-float

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -154,6 +154,7 @@ export class WindowManager extends GObject.Object {
 
     if (floatingExempt) {
       this.removeFloatOverride(metaWindow, withWmId);
+      this.windowProps = this.ext.configMgr.windowProps;
       if (!this.isActiveWindowWorkspaceTiled(metaWindow)) {
         nodeWindow.mode = WINDOW_MODES.FLOAT;
       } else {
@@ -161,6 +162,7 @@ export class WindowManager extends GObject.Object {
       }
     } else {
       this.addFloatOverride(metaWindow, withWmId);
+      this.windowProps = this.ext.configMgr.windowProps;
       nodeWindow.mode = WINDOW_MODES.FLOAT;
     }
   }


### PR DESCRIPTION
After PR #484, the window-toggle-float and window-toggle-always-float shortcuts stopped working. The root cause was that addFloatOverride and removeFloatOverride save overrides via configMgr (disk), but isFloatingExempt reads from this.windowProps (in-memory cache) which was never refreshed after the save.

Fixes #492, #495"