### PR TITLE
metadata: add support for GNOME Shell version 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "gettext-domain": "forge",
   "uuid": "forge@jmmaranan.com",
   "settings-schema": "org.gnome.shell.extensions.forge",
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "session-modes": ["user", "unlock-dialog"],
   "url": "https://github.com/forge-ext/forge"
 }


### PR DESCRIPTION
Add support for GNOME Shell 50 by adding that version to the metadata. The extension is verified to some extent that it works, even with GNOME 50 (tested).