### PR TITLE
Update Forge GNOME extension fork to main

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -940,7 +940,7 @@ export class WindowManager extends GObject.Object {
   }
 
   hideWindowBorders() {
-    this.tree.nodeWindows.forEach((nodeWindow) => {
+    this.allNodeWindows.forEach((nodeWindow) => {
       let actor = nodeWindow.windowActor;
       if (actor) {
         this.hideActorBorder(actor);
@@ -1238,8 +1238,7 @@ export class WindowManager extends GObject.Object {
     return firstMonWs === secondMonWs;
   }
 
-  showWindowBorders() {
-    let metaWindow = this.focusMetaWindow;
+  showWindowBordersFor(metaWindow) {
     if (!metaWindow) return;
     let windowActor = metaWindow.get_compositor_private();
     if (!windowActor) return;
@@ -1333,7 +1332,7 @@ export class WindowManager extends GObject.Object {
       focusBorderEnabled &&
       tilingModeEnabled &&
       !nodeWindow.isFloat() &&
-      !maximized &&
+      !maximized() &&
       parentNode.childNodes.length === 1 &&
       (parentNode.isCon() || parentNode.isMonitor()) &&
       !(parentNode.isTabbed() || parentNode.isStacked())
@@ -1361,13 +1360,21 @@ export class WindowManager extends GObject.Object {
     borders.forEach((border) => {
       border.set_size(rect.width + inset * 2, rect.height + inset * 2);
       border.set_position(rect.x - inset, rect.y - inset);
-      if (metaWindow.appears_focused && !metaWindow.minimized) {
-        border.show();
+
+      // show for both focused + unfocused
+      if (!metaWindow.minimized) border.show();
+
+      // mark unfocused borders for CSS
+      if (!metaWindow.appears_focused) {
+        border.add_style_class_name("window-unfocused");
+      } else {
+        border.remove_style_class_name("window-unfocused");
       }
+
       if (global.window_group && global.window_group.contains(border)) {
         // TODO - sort the borders with split border being on top
         global.window_group.remove_child(border);
-        // Add the border just above the focused window
+        // Add the border just above its own window
         global.window_group.insert_child_above(border, metaWindow.get_compositor_private());
       }
     });
@@ -1375,7 +1382,23 @@ export class WindowManager extends GObject.Object {
 
   updateBorderLayout() {
     this.hideWindowBorders();
-    this.showWindowBorders();
+
+    const activeWs = global.workspace_manager.get_active_workspace();
+
+    for (const nodeWindow of this.allNodeWindows) {
+      const w = nodeWindow.nodeValue;
+      if (!w) continue;
+      if (w.minimized) continue;
+
+      // Only draw borders for windows that belong to the active workspace,
+      // unless they are on all workspaces.
+      if (!w.is_on_all_workspaces() && w.get_workspace() !== activeWs) continue;
+
+      // Extra safety: some windows report false here while switching workspaces
+      if (!w.showing_on_its_workspace()) continue;
+
+      this.showWindowBordersFor(w);
+    }
   }
 
   calculateGaps(node) {


### PR DESCRIPTION
Refactor showWindowBorders() into showWindowBordersFor(metaWindow) so borders can be drawn for any window, not just the focused one. Then updateBorderLayout() iterates over every tracked node-window on the active workspace and renders a border for each non-minimized window, tagging unfocused ones with the `window-unfocused` style class so themes can distinguish them from the focused border.

Also fix a latent bug in the split-border guard where `!maximized` was checking truthiness of the arrow function (always true) instead of invoking it as `!maximized()`.