### PR TITLE
fix: disconnect FeatureIndicator settings handler + correct theme cleanup

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -65,7 +65,9 @@ export default class ForgeExtension extends Extension {
     this.keybindings?.disable();
     this.keybindings = null;
     this.extWm = null;
-    this.themeWm = null;
+    // The field assigned in enable() is `this.theme`, not `this.themeWm`,
+    // so the previous statement was a no-op leaving `this.theme` dangling.
+    this.theme = null;
     this.configMgr = null;
     this.settings = null;
     this.kbdSettings = null;

--- a/lib/extension/indicator.js
+++ b/lib/extension/indicator.js
@@ -118,12 +118,23 @@ export class FeatureIndicator extends SystemIndicator {
 
     this._indicator.visible = tilingModeEnabled && quickSettingsEnabled;
 
-    this.extension.settings.connect("changed", (_, name) => {
+    // settings is a long-lived Gio.Settings (cached by getSettings()) so we
+    // must disconnect on destroy — otherwise every enable/disable cycle
+    // accumulates another handler firing on the previous indicator.
+    this._settingsChangedId = this.extension.settings.connect("changed", (_, name) => {
       switch (name) {
         case "tiling-mode-enabled":
         case "quick-settings-enabled":
           this._indicator.visible = this.extension.settings.get_boolean(name);
       }
     });
+  }
+
+  destroy() {
+    if (this._settingsChangedId) {
+      this.extension.settings.disconnect(this._settingsChangedId);
+      this._settingsChangedId = 0;
+    }
+    super.destroy();
   }
 }


### PR DESCRIPTION
## Summary

Two small lifecycle fixes that surface during repeated `enable`/`disable` cycles (a common path during development, plus user-triggered prefs reloads or extension scans).

### 1. `FeatureIndicator` leaks a `settings` signal handler

`indicator.js` connects to `extension.settings.connect("changed", …)` in the constructor without storing the handler id. `Gio.Settings` returned by `getSettings()` is **cached for the lifetime of the gnome-shell process**, so the handler outlives the indicator. Every `enable`/`disable` cycle adds another listener; toggling `tiling-mode-enabled` or `quick-settings-enabled` then fires N callbacks, each operating on a previous (destroyed) indicator object.

Fix: store the id, override `destroy()` to disconnect.

### 2. `extension.js` disable() typo: `themeWm` instead of `theme`

`enable()` assigns `this.theme = new ExtensionThemeManager(this)`, but `disable()` was clearing `this.themeWm = null` — a no-op that left `this.theme` referencing the manager after disable. Replaced with `this.theme = null` and added a comment explaining the previous typo.

## Test plan

- [x] `node --check` on both touched files.
- [x] Manual reload cycles via `gnome-extensions disable forge@jmmaranan.com && gnome-extensions enable forge@jmmaranan.com` repeated several times — no journal warnings about `tiling-mode-enabled` callbacks firing on destroyed objects.
- [x] Toggle `Super+T` after multiple reloads — only one settings listener active.

## Notes

- Both changes are zero-behaviour for the happy path; they only affect state cleanup at disable time.
- The settings leak compounds over time, so it can hide other extension bugs by spraying spurious GC sweep warnings into the journal.