### PR TITLE
cleanup: remove deprecated accelerator-grabber API

### DIFF
--- a/lib/extension/keybindings.js
+++ b/lib/extension/keybindings.js
@@ -38,31 +38,11 @@ export class Keybindings extends GObject.Object {
   constructor(ext) {
     super();
     Logger.debug(`created keybindings`);
-    this._grabbers = new Map();
-    // this._bindSignals();
     this.ext = ext;
     this.extWm = ext.extWm;
     this.kbdSettings = ext.kbdSettings;
     this.settings = ext.settings;
     this.buildBindingDefinitions();
-  }
-
-  // @deprecated
-  _acceleratorActivate(action) {
-    let grabber = this._grabbers.get(action);
-    if (grabber) {
-      Logger.debug(`Firing accelerator ${grabber.accelerator} : ${grabber.name}`);
-      grabber.callback();
-    } else {
-      Logger.error(`No listeners [action={${action}}]`);
-    }
-  }
-
-  // @deprecated
-  _bindSignals() {
-    global.display.connect("accelerator-activated", (_display, action, _deviceId, _timestamp) => {
-      this._acceleratorActivate(action);
-    });
   }
 
   enable() {
@@ -89,63 +69,6 @@ export class Keybindings extends GObject.Object {
     }
 
     Logger.debug(`keybindings:disable`);
-  }
-
-  // @deprecated
-  enableListenForBindings() {
-    windowConfig.forEach((config) => {
-      config.shortcut.forEach((shortcut) => {
-        this.listenFor(shortcut, () => {
-          config.actions.forEach((action) => {
-            this.extWm.command(action);
-          });
-        });
-      });
-    });
-  }
-
-  // @deprecated
-  disableListenForBindings() {
-    // The existing grabber items are from the custom config by
-    // this extension.
-    this._grabbers.forEach((grabber) => {
-      global.display.ungrab_accelerator(grabber.action);
-      Main.wm.allowKeybinding(grabber.name, Shell.ActionMode.NONE);
-    });
-
-    this._grabbers.clear();
-  }
-
-  /**
-   * API for quick binding of keys to function. This is going to be useful with SpaceMode
-   *
-   * @param {String} accelerator - keybinding combinations
-   * @param {Function} callback - function to call when the accelerator is invoked
-   *
-   * Credits:
-   *  - https://superuser.com/a/1182899
-   *  - Adapted based on current Gnome-shell API or syntax
-   */
-  listenFor(accelerator, callback) {
-    let grabFlags = Meta.KeyBindingFlags.NONE;
-    let action = global.display.grab_accelerator(accelerator, grabFlags);
-
-    if (action == Meta.KeyBindingAction.NONE) {
-      Logger.error(`Unable to grab accelerator [binding={${accelerator}}]`);
-      // TODO - check the gnome keybindings for conflicts and notify the user
-    } else {
-      let name = Meta.external_binding_name_for_action(action);
-
-      Logger.debug(`Requesting WM to allow binding [name={${name}}]`);
-      Main.wm.allowKeybinding(name, Shell.ActionMode.ALL);
-
-      this._grabbers.set(action, {
-        name: name,
-        accelerator: accelerator,
-        callback: callback,
-        action: action,
-      });
-    }
   }
 
   get modifierState() {


### PR DESCRIPTION
## Summary

`lib/extension/keybindings.js` has five `@deprecated` symbols that predate the move to `Main.wm.addKeybinding` (the API that the live `enable()`/`disable()` methods actually use). They have no callers anywhere in the codebase, and one of them (`enableListenForBindings`) references an undefined `windowConfig` identifier — it would throw `ReferenceError` the moment anything called it.

## Removed

- `_acceleratorActivate` — old `accelerator-activated` signal handler
- `_bindSignals` — connected the dead handler
- `enableListenForBindings` — referenced undefined `windowConfig`
- `disableListenForBindings` — paired with the above
- `listenFor` — manual `grab_accelerator`/`allowKeybinding` plumbing
- `_grabbers` Map field — only used by the above
- The commented-out `// this._bindSignals();` line in the constructor

77 lines deleted, no behaviour change.

## Test plan

- [x] `node --check lib/extension/keybindings.js`
- [x] `grep -rn` confirmed no external callers of any removed symbol
- [x] `gnome-extensions disable forge && gnome-extensions enable forge` — keybindings still register and fire (`Super+H/J/K/L`, etc.)

## Notes

Filed as a separate PR from #520 / #521 because it's a pure deletion with a different review surface.