### PR TITLE
fix: disconnect WindowManager settings handler on disable

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -289,7 +289,7 @@ export class WindowManager extends GObject.Object {
 
     let settings = this.ext.settings;
 
-    settings.connect("changed", (_, settingName) => {
+    this._settingsChangedId = settings.connect("changed", (_, settingName) => {
       switch (settingName) {
         case "window-overrides-reload-trigger":
           // Reload window overrides when triggered by preferences
@@ -1156,6 +1156,11 @@ export class WindowManager extends GObject.Object {
       }
       this._overviewSignals.length = 0;
       this._overviewSignals = null;
+    }
+
+    if (this._settingsChangedId) {
+      this.ext.settings.disconnect(this._settingsChangedId);
+      this._settingsChangedId = 0;
     }
 
     this._signalsBound = false;


### PR DESCRIPTION
## Summary

Same shape as #521 but in `WindowManager._bindSignals()`. The `extension.settings.connect("changed", …)` call doesn't capture the handler id, and `_removeSignals()` doesn't disconnect it. Because `Gio.Settings` is cached for the lifetime of the gnome-shell process, the handler outlives every enable/disable cycle — each cycle adds one more, and toggling any setting (`tiling-mode-enabled`, `window-gap-size`, `focus-border-toggle`, …) eventually fires the switch on disposed `WindowManager` instances.

## Fix

- Store the handler id on `this._settingsChangedId` at connect time.
- Disconnect in `_removeSignals()` alongside the existing display / window_manager / workspace_manager / overview cleanups.

## Test plan

- [x] `node --check`
- [x] Repeated `gnome-extensions disable forge && gnome-extensions enable forge` cycles, then toggling `tiling-mode-enabled`: settings change runs once per toggle (not N times).
- [x] No `JS ERROR` rows in the journal mentioning `tree` / `renderTree` after several reload cycles.

## Notes

Together with #521, this clears all settings-handler leaks I could find. There's no remaining `*.connect("changed"` without a paired disconnect after these two PRs.