### PR TITLE
fix: correct operator precedence on grabOp tabbed-focus guard

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -1735,7 +1735,7 @@ export class WindowManager extends GObject.Object {
 
             // Ensure that the workspace tiling is honored
             if (this.isActiveWindowWorkspaceTiled(metaWindow)) {
-              if (!this.grabOp === Meta.GrabOp.WINDOW_BASE) this.updateTabbedFocus(existNodeWindow);
+              if (this.grabOp !== Meta.GrabOp.WINDOW_BASE) this.updateTabbedFocus(existNodeWindow);
               this.updateStackedFocus(existNodeWindow);
             } else {
               if (this.floatingWindow(existNodeWindow)) {


### PR DESCRIPTION
## Summary

`updateMetaWorkspaceMonitor()` has

```js
if (!this.grabOp === Meta.GrabOp.WINDOW_BASE)
  this.updateTabbedFocus(existNodeWindow);
```

JavaScript binds `!` tighter than `===`, so this evaluates as `(!this.grabOp) === Meta.GrabOp.WINDOW_BASE` — a boolean compared to an integer, which is **always false**. `updateTabbedFocus` has never run from this code path.

Every other `Meta.GrabOp` comparison in the codebase is of the form `grabOp === Meta.GrabOp.X` (see `lib/extension/utils.js` lines 227–250, `lib/extension/window.js` line 2515 in the same file), so the typo is an isolated mistake.

Intent (matching the comment _"Ensure that the workspace tiling is honored"_): skip the update **only** when the grab op is `WINDOW_BASE` (i.e. don't yank tabbed focus mid-drag). Fix:

```diff
- if (!this.grabOp === Meta.GrabOp.WINDOW_BASE) this.updateTabbedFocus(existNodeWindow);
+ if (this.grabOp !== Meta.GrabOp.WINDOW_BASE) this.updateTabbedFocus(existNodeWindow);
```

## User-visible effect

In a tabbed container, when a tabbed window is moved across workspaces or monitors *without* an active drag (e.g. via keyboard, programmatic move, dynamic workspace shift), the tab header should re-render to follow the focused window — currently it doesn't, because the `updateTabbedFocus` call is dead code.

## Test plan

- [x] `node --check`
- [x] Move a window from a tabbed container to another workspace via `Super+Shift+1..9`: with the fix, the tab head on the source workspace re-renders correctly.

## Notes

This is the kind of bug a typechecker (TS or even just `eslint --no-mixed-operators`) would catch on the first pass; might be worth wiring one in eventually, but out of scope for this fix.