### PR TITLE
fix: replace imports.byteArray with TextDecoder (broken on GNOME 48+)

### DIFF
--- a/lib/shared/settings.js
+++ b/lib/shared/settings.js
@@ -120,8 +120,7 @@ export class ConfigManager extends GObject.Object {
   loadFileContents(configFile) {
     let [success, contents] = configFile.load_contents(null);
     if (success) {
-      const stringContents = imports.byteArray.toString(contents);
-      return stringContents;
+      return new TextDecoder().decode(contents);
     }
   }
 
@@ -135,7 +134,7 @@ export class ConfigManager extends GObject.Object {
 
     let [success, contents] = windowConfigFile.load_contents(null);
     if (success) {
-      const windowConfigContents = imports.byteArray.toString(contents);
+      const windowConfigContents = new TextDecoder().decode(contents);
       Logger.trace(`${windowConfigContents}`);
       windowProps = JSON.parse(windowConfigContents);
     }


### PR DESCRIPTION
## Summary

`lib/shared/settings.js` reads window-floating config via:

```js
const stringContents = imports.byteArray.toString(contents);
```

GJS removed `imports.byteArray` in **1.86 (shipped with GNOME 48)**. Forge has been ESM since the GNOME 45 port, where the legacy `imports` global is gone — calling `imports.byteArray.toString(...)` throws `ReferenceError: imports is not defined`.

## When it bites users

The default `config/windows.json` ships inside the extension dir, so the *read* path is rarely hit on a clean install. But every `Super+Shift+C` ("Toggle always float for this class") goes through `windowProps` getter / setter, which reads + writes that JSON. On GNOME 48+, the first toggle throws and the always-float entry never persists.

## Fix

Both call sites switch to `new TextDecoder().decode(contents)`:

```diff
- const stringContents = imports.byteArray.toString(contents);
+ return new TextDecoder().decode(contents);
```

`Gio.File.load_contents()` returns a `Uint8Array` on GJS 1.74+, which `TextDecoder` accepts directly.

## Test plan

- [x] `node --check lib/shared/settings.js`
- [x] `Super+Shift+C` on a window persists the class to `~/.config/forge/config/windows.json`; subsequent windows of that class open floating.
- [x] No `JS ERROR: ReferenceError: imports is not defined` in the journal under the patched extension.