### PR TITLE
fix: clear this.grabOp when the grab ends

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -2540,6 +2540,11 @@ export class WindowManager extends GObject.Object {
     this.updateStackedFocus(focusNodeWindow);
     this.updateTabbedFocus(focusNodeWindow);
     this.nodeWinAtPointer = null;
+    // Clear grabOp now that the operation is done. The flag is read by
+    // updateMetaWorkspaceMonitor() to know whether a tabbed-focus update
+    // is safe; leaving it stuck on the last value (e.g. WINDOW_BASE)
+    // would suppress that update for the rest of the session.
+    this.grabOp = null;
   }
 
   _grabCleanup(focusNodeWindow) {


### PR DESCRIPTION
## Summary

`_handleGrabOpBegin` writes `this.grabOp = grabOp`. `_handleGrabOpEnd` never clears it.

`this.grabOp` is read by:

1. `updateMetaWorkspaceMonitor()` — to decide whether the tabbed-focus update is safe (skip during a drag).
2. `_handleResizing()` — to decompose the grab type into directions during an active resize.

Consumer (2) only runs during an active resize grab, so a stale value can't reach it. Consumer (1) is the problem: after the user's first base grab, `this.grabOp` retains `Meta.GrabOp.WINDOW_BASE` for the entire session, and every subsequent workspace/monitor change for a tabbed window goes through the "skip update" branch — even when no grab is in progress.

## Fix

Clear `this.grabOp = null` at the end of `_handleGrabOpEnd`.

## Pairs with #524

#524 corrects the operator-precedence bug on the same condition. Without **this** clear, the precedence fix would mostly go back to a no-op after the user's first drag, because the flag stays stuck on `WINDOW_BASE`. They're independent (either could land first) but the user-visible behaviour only becomes correct with both.

## Test plan

- [x] `node --check`
- [x] After dragging a window once (any drag), then moving a tabbed window across workspaces with `Super+Shift+1..9`: the tab head re-renders correctly. Without this fix, the tab head would never update again until gnome-shell restart.