### PR TITLE
fix: LayoutToggle silent no-op when parent is not HSPLIT/VSPLIT

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -576,6 +576,13 @@ export class WindowManager extends GObject.Object {
           focusNodeWindow.parentNode.layout = LAYOUT_TYPES.VSPLIT;
         } else if (currentLayout === LAYOUT_TYPES.VSPLIT) {
           focusNodeWindow.parentNode.layout = LAYOUT_TYPES.HSPLIT;
+        } else {
+          // Tabbed/stacked/monitor parent — fall back to a split layout
+          // so the binding always does something. Without this, focusing
+          // a window whose parent is not already an HSPLIT/VSPLIT (e.g.
+          // sitting directly under MONITOR, or inside a tabbed container)
+          // makes Super+G a silent no-op.
+          focusNodeWindow.parentNode.layout = this.determineSplitLayout();
         }
         this.tree.attachNode = focusNodeWindow.parentNode;
         this.renderTree("layout-split-toggle");


### PR DESCRIPTION
## Summary

`LayoutToggle` (the action behind `con-split-layout-toggle`, default `Super+G`) only swaps between `HSPLIT` and `VSPLIT`. Every other parent layout (`TABBED`, `STACKED`, or the bare `MONITOR` container) hits the implicit fallthrough and the action is a silent no-op — same shortcut, no feedback, no error.

## Reproducible case

Three windows side-by-side where Forge nested them as:

```
HSPLIT
├── W1
└── HSPLIT-or-TABBED
    ├── W2
    └── W3
```

- Focus W1 → parent = outer HSPLIT → Super+G works.
- Focus W3 → parent = inner HSPLIT-or-VSPLIT → Super+G works.
- Focus W2 with the inner container in tabbed mode → parent = TABBED → Super+G silently does nothing.

Reported on a multi-monitor setup as "the middle window won't toggle."

## Fix

Fall back to `determineSplitLayout()` (which returns `HSPLIT` or `VSPLIT` depending on monitor orientation) when the current layout is anything other than a split. The binding then always has a visible effect — toggling out of tabbed/stacked/monitor mode into a sensible split.

```diff
       case "LayoutToggle":
         if (!focusNodeWindow) return;
         currentLayout = focusNodeWindow.parentNode.layout;
         if (currentLayout === LAYOUT_TYPES.HSPLIT) {
           focusNodeWindow.parentNode.layout = LAYOUT_TYPES.VSPLIT;
         } else if (currentLayout === LAYOUT_TYPES.VSPLIT) {
           focusNodeWindow.parentNode.layout = LAYOUT_TYPES.HSPLIT;
+        } else {
+          focusNodeWindow.parentNode.layout = this.determineSplitLayout();
         }
```

## Test plan

- [x] `node --check`
- [x] In a workspace with 3 windows where the middle pair is in a tabbed container, focus the middle window and press `Super+G` → container becomes HSPLIT/VSPLIT.
- [x] In an HSPLIT container, Super+G still toggles to VSPLIT (and vice-versa), no regression.